### PR TITLE
Switched to Iso8601DateFormatter, fixed authorizations poll, added requests timeout

### DIFF
--- a/Example/Authenticator/Coordinators/Tab Bar/AuthorizationsCoordinator.swift
+++ b/Example/Authenticator/Coordinators/Tab Bar/AuthorizationsCoordinator.swift
@@ -113,7 +113,7 @@ private extension AuthorizationsCoordinator {
                 }
             },
             failure: { error in
-                self.rootViewController.present(message: error, style: .error)
+                print(error)
             },
             connectionNotFoundFailure: { connectionId in
                 if let id = connectionId, let connection = ConnectionsCollector.with(id: id) {

--- a/Example/Authenticator/Utils/Interactors/AuthorizationsInteractor.swift
+++ b/Example/Authenticator/Utils/Interactors/AuthorizationsInteractor.swift
@@ -66,6 +66,16 @@ struct AuthorizationsInteractor {
 
         var encryptedAuthorizations = [SEEncryptedAuthorizationResponse]()
 
+        var numberOfResponses = 0
+
+        func incrementAndCheckResponseCount() {
+            numberOfResponses += 1
+
+            if numberOfResponses == connections.count {
+                success(encryptedAuthorizations)
+            }
+        }
+
         for connection in connections {
             let accessToken = connection.accessToken
 
@@ -82,11 +92,11 @@ struct AuthorizationsInteractor {
                 onSuccess: { response in
                     encryptedAuthorizations.append(contentsOf: response.data)
 
-                    if encryptedAuthorizations != response.data {
-                        success(encryptedAuthorizations)
-                    }
+                    incrementAndCheckResponseCount()
                 },
                 onFailure: { error in
+                    incrementAndCheckResponseCount()
+
                     if SEAPIError.connectionNotFound.isConnectionNotFound(error) {
                         connectionNotFoundFailure(connection.id)
                     } else {

--- a/Example/Authenticator/Utils/Interactors/AuthorizationsInteractor.swift
+++ b/Example/Authenticator/Utils/Interactors/AuthorizationsInteractor.swift
@@ -64,8 +64,6 @@ struct AuthorizationsInteractor {
                         connectionNotFoundFailure: @escaping ((String?) -> ())) {
         let expiresAt = Date().addingTimeInterval(5.0 * 60.0).utcSeconds
 
-        var numberOfResponses = 0
-
         var encryptedAuthorizations = [SEEncryptedAuthorizationResponse]()
 
         for connection in connections {
@@ -83,8 +81,8 @@ struct AuthorizationsInteractor {
                 expiresAt: expiresAt,
                 onSuccess: { response in
                     encryptedAuthorizations.append(contentsOf: response.data)
-                    numberOfResponses += 1
-                    if numberOfResponses == connections.count {
+
+                    if encryptedAuthorizations != response.data {
                         success(encryptedAuthorizations)
                     }
                 },
@@ -92,7 +90,7 @@ struct AuthorizationsInteractor {
                     if SEAPIError.connectionNotFound.isConnectionNotFound(error) {
                         connectionNotFoundFailure(connection.id)
                     } else {
-                        failure?(error)
+                        failure?("\(l10n(.somethingWentWrong)) (\(connection.name))")
                     }
                 }
             )

--- a/Example/Tests/Helpers/DateUtilsSpec.swift
+++ b/Example/Tests/Helpers/DateUtilsSpec.swift
@@ -30,7 +30,7 @@ class DateUtilsSpec: BaseSpec {
             it("should return the proper ISO8601 date formatter") {
                 let fmt = DateUtils.iso8601dateFormatter
 
-                expect(fmt.dateFormat).to(equal("yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"))
+                expect(fmt.dateFormat).to(equal("yyyy-MM-dd'T'HH:mm:ssXXXXX"))
                 expect(fmt.timeZone).to(equal(TimeZone.utc))
                 expect(fmt.locale).to(equal(Locale(identifier: "en_US_POSIX")))
                 expect(fmt.calendar).to(equal(Calendar(identifier: .iso8601)))
@@ -39,7 +39,7 @@ class DateUtilsSpec: BaseSpec {
 
         describe("iso8601date") {
             it("should return date in iso8601 format") {
-                let dateString = "2013-07-21T11:02:02.000Z"
+                let dateString = "2013-07-21T11:02:02Z"
 
                 var dateComponents = DateComponents()
                 dateComponents.year = 2013

--- a/Example/Tests/Helpers/DateUtilsSpec.swift
+++ b/Example/Tests/Helpers/DateUtilsSpec.swift
@@ -26,17 +26,6 @@ import Nimble
 
 class DateUtilsSpec: BaseSpec {
     override func spec() {
-        describe("iso8601dateFormatter") {
-            it("should return the proper ISO8601 date formatter") {
-                let fmt = DateUtils.iso8601dateFormatter
-
-                expect(fmt.dateFormat).to(equal("yyyy-MM-dd'T'HH:mm:ssXXXXX"))
-                expect(fmt.timeZone).to(equal(TimeZone.utc))
-                expect(fmt.locale).to(equal(Locale(identifier: "en_US_POSIX")))
-                expect(fmt.calendar).to(equal(Calendar(identifier: .iso8601)))
-            }
-        }
-
         describe("iso8601date") {
             it("should return date in iso8601 format") {
                 let dateString = "2013-07-21T11:02:02Z"

--- a/Example/Tests/Models/Structures/DecryptedAuthorizationDataSpec.swift
+++ b/Example/Tests/Models/Structures/DecryptedAuthorizationDataSpec.swift
@@ -42,8 +42,8 @@ class DecryptedAuthorizationDataSpec: BaseSpec {
                     expect(expectedData.connectionId).to(equal("12345"))
                     expect(expectedData.title).to(equal("Authorization"))
                     expect(expectedData.description).to(equal("Test authorization"))
-                    expect(expectedData.createdAt.iso8601string).to(equal("2019-05-20T09:30:40Z"))
-                    expect(expectedData.expiresAt.iso8601string).to(equal("2019-05-20T09:30:45Z"))
+                    expect(expectedData.createdAt.iso8601string).to(equal("2019-05-20T09:30:40"))
+                    expect(expectedData.expiresAt.iso8601string).to(equal("2019-05-20T09:30:45"))
                     expect(expectedData.authorizationCode).to(equal("11"))
                 }
             }

--- a/Example/Tests/Models/Structures/DecryptedAuthorizationDataSpec.swift
+++ b/Example/Tests/Models/Structures/DecryptedAuthorizationDataSpec.swift
@@ -33,8 +33,8 @@ class DecryptedAuthorizationDataSpec: BaseSpec {
                                        "connection_id": "12345",
                                        "title": "Authorization",
                                        "description": "Test authorization",
-                                       "created_at": "2019-05-20T09:30:40.378Z",
-                                       "expires_at": "2019-05-20T09:30:45.378Z",
+                                       "created_at": "2019-05-20T09:30:40Z",
+                                       "expires_at": "2019-05-20T09:30:45Z",
                                        "authorization_code": "11"]
                     let expectedData = SEDecryptedAuthorizationData(authMessage)!
                     
@@ -42,8 +42,8 @@ class DecryptedAuthorizationDataSpec: BaseSpec {
                     expect(expectedData.connectionId).to(equal("12345"))
                     expect(expectedData.title).to(equal("Authorization"))
                     expect(expectedData.description).to(equal("Test authorization"))
-                    expect(expectedData.createdAt.iso8601string).to(equal("2019-05-20T09:30:40.378Z"))
-                    expect(expectedData.expiresAt.iso8601string).to(equal("2019-05-20T09:30:45.378Z"))
+                    expect(expectedData.createdAt.iso8601string).to(equal("2019-05-20T09:30:40Z"))
+                    expect(expectedData.expiresAt.iso8601string).to(equal("2019-05-20T09:30:45Z"))
                     expect(expectedData.authorizationCode).to(equal("11"))
                 }
             }
@@ -53,7 +53,7 @@ class DecryptedAuthorizationDataSpec: BaseSpec {
                     let authMessage = ["id": "00000",
                                        "title": "Authorization",
                                        "description": "Test authorization",
-                                       "created_at": "2019-05-20T09:30:40.378Z",
+                                       "created_at": "2019-05-20T09:30:40Z",
                                        "expires_at": "2019-05-20T09:30:45.378Z"]
                     let expectedData = SEDecryptedAuthorizationData(authMessage)
 

--- a/SaltedgeAuthenticatorSDK/Classes/API/Managers/URLSessionManager.swift
+++ b/SaltedgeAuthenticatorSDK/Classes/API/Managers/URLSessionManager.swift
@@ -38,6 +38,8 @@ struct URLSessionManager {
 
     static func createSession() -> URLSession {
         let config: URLSessionConfiguration = .default
+        config.timeoutIntervalForRequest = 10.0
+        config.timeoutIntervalForResource = 30.0
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
 
         return URLSession(configuration: config)

--- a/SaltedgeAuthenticatorSDK/Classes/Helpers/DateUtils.swift
+++ b/SaltedgeAuthenticatorSDK/Classes/Helpers/DateUtils.swift
@@ -23,19 +23,16 @@
 import Foundation
 
 public struct DateUtils {
-    static var iso8601dateFormatter: DateFormatter {
-        return sharedInstance.iso8601dateFormatter
+    static var iso8601dateFormatter: ISO8601DateFormatter {
+        return shared.iso8601dateFormatter
     }
-    
-    private static let sharedInstance = DateUtils()
-    
-    // NOTE: We use XXXXX instead of Z to avoid appending of GMT offset
-    private var iso8601dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
-        formatter.timeZone = TimeZone.utc
-        formatter.locale = Locale(identifier: "en_US_POSIX")
+
+    private static let shared = DateUtils()
+
+    private var iso8601dateFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = .utc
+        formatter.formatOptions = [.withFullDate, .withTime, .withDashSeparatorInDate, .withColonSeparatorInTime]
         return formatter
     }()
 }

--- a/SaltedgeAuthenticatorSDK/Classes/Helpers/DateUtils.swift
+++ b/SaltedgeAuthenticatorSDK/Classes/Helpers/DateUtils.swift
@@ -33,7 +33,7 @@ public struct DateUtils {
     private var iso8601dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.calendar = Calendar(identifier: .iso8601)
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssXXXXX"
         formatter.timeZone = TimeZone.utc
         formatter.locale = Locale(identifier: "en_US_POSIX")
         return formatter


### PR DESCRIPTION
- Switched to default Swift ISO8601DateFormatter
- Fixed authorizations poll
- Removed errors from authorizations screen (issue #79)
- Added request timeout